### PR TITLE
Configuring codetour for part 1 of the workshop

### DIFF
--- a/.tours/terraforming-the-cloud-azure-1.tour
+++ b/.tours/terraforming-the-cloud-azure-1.tour
@@ -1,0 +1,377 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "terraforming-the-cloud-azure-1",
+  "steps": [
+    {
+      "file": "README.md",
+      "description": "Bem-vindo ao workshop!\n\nAqui tens um breve resumo dos conteúdos abordados neste módulo.\n\nAproveita para dar uma vista de olhos nos tópicos e verificar se tens todos os requisitos para prosseguir com o workshop.",
+      "line": 1
+    },
+    {
+      "file": "README.md",
+      "description": "Para começar faz login em Azure utilizando o comando:\n- **az login**",
+      "line": 11
+    },
+    {
+      "file": "README.md",
+      "description": "Para definir a subscrição corre o seguinte comando:\n\n- **az account set --subscription**\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n- **az account list --output table**",
+      "line": 13,
+      "selection": {
+        "start": {
+          "line": 7,
+          "character": 5
+        },
+        "end": {
+          "line": 7,
+          "character": 35
+        }
+      }
+    },
+    {
+      "file": "README.md",
+      "description": "Certifica-te que estás na subscrição correcta utilizando o comando:\n\n- **az account show**",
+      "line": 12
+    },
+    {
+      "file": "main.tf",
+      "description": "1. **O primeiro contacto**\n\nNesta secção iremos executar os 4 principais comandos de terraform: init, plan, apply e destroy.\n\n**[terraform init](https://developer.hashicorp.com/terraform/cli/commands/init)**\n- The terraform init command is used to initialize a working directory containing Terraform configuration files. This is the first command that should be run after writing a new Terraform configuration or cloning an existing one from version control. It is safe to run this command multiple times.\n\n**[terraform plan](https://developer.hashicorp.com/terraform/cli/commands/plan)**\n- The terraform plan command creates an execution plan, which lets you preview the changes that Terraform plans to make to your infrastructure. By default, when Terraform creates a plan it:\n\n- Reading the current state of any already-existing remote objects to make sure that the Terraform state is up-to-date.\n- Comparing the current configuration to the prior state and noting any differences.\n- Proposing a set of change actions that should, if applied, make the remote objects match the configuration.\n\n**[terraform apply](https://developer.hashicorp.com/terraform/cli/commands/apply)**\n- The terraform apply command executes the actions proposed in a Terraform plan.\n\n**[terraform destroy](https://developer.hashicorp.com/terraform/cli/commands/destroy)**\n- The terraform destroy command is a convenient way to destroy all remote objects managed by a particular Terraform configuration.\n\nWhile you will typically not want to destroy long-lived objects in a production environment, Terraform is sometimes used to manage ephemeral infrastructure for development purposes, in which case you can use terraform destroy to conveniently clean up all of those temporary objects once you are finished with your work.",
+      "line": 1,
+      "selection": {
+        "start": {
+          "line": 18,
+          "character": 3
+        },
+        "end": {
+          "line": 18,
+          "character": 18
+        }
+      }
+    },
+    {
+      "file": "main.tf",
+      "description": "Para começar executa o comando:\n\n- **terraform init**",
+      "line": 2,
+      "selection": {
+        "start": {
+          "line": 1,
+          "character": 1
+        },
+        "end": {
+          "line": 3,
+          "character": 21
+        }
+      }
+    },
+    {
+      "file": "main.tf",
+      "description": "Para veres as alterações a serem feitas à tua infraestrutura executa o comando:\n\n- **terraform plan**",
+      "line": 3
+    },
+    {
+      "file": "main.tf",
+      "description": "Para aplicares as alterações executa o comando:\n\n- **terraform apply**\n\n❗Não te esqueças de escrever **yes** para confirmar o apply.\n\n⏳ Tempo do apply - 1 min.",
+      "line": 4
+    },
+    {
+      "file": "main.tf",
+      "description": "Para verificares que os recursos remotos foram criados executa o comando:\n\n- **az group show --name=$(terraform output -raw my_identifier)-rg --output table**",
+      "line": 5,
+      "selection": {
+        "start": {
+          "line": 3,
+          "character": 5
+        },
+        "end": {
+          "line": 3,
+          "character": 82
+        }
+      }
+    },
+    {
+      "file": "main.tf",
+      "description": "Examina todos os resource groups criados com o comando:\n\n- **az group list --output table**",
+      "line": 6
+    },
+    {
+      "file": "main.tf",
+      "description": "Vamos destruir os recursos, para tal executa o comando:\n\n- **terraform destroy**",
+      "line": 7
+    },
+    {
+      "file": "main.tf",
+      "description": "Confirma a destruição dos recursos:\n\n- **az group show --name=$(terraform output -raw my_identifier)-rg**\n\n\nDeverá apresentar um erro a dizer **No outputs found** porque estes foram destruídos.",
+      "line": 8,
+      "selection": {
+        "start": {
+          "line": 6,
+          "character": 37
+        },
+        "end": {
+          "line": 6,
+          "character": 53
+        }
+      }
+    },
+    {
+      "file": "main.tf",
+      "description": "2. Lidar com as alterações\n\nNesta secção iremos demonstrar a utilização de terraform perante vários tipos de alterações.\n\nDescomenta o bloco referente ao **Exercicio 2.**\n\n- Seleciona o bloco referente ao **Exercício 2** e de seguida **ctrl+k+u** ou se estiveres num mac **cmd+k+u**.",
+      "line": 58
+    },
+    {
+      "file": "main.tf",
+      "description": "❗Não te esqueças de salvar o ficheiro depois de fazeres alterações.\n\n- **ctrl+s** ou se estiveres num mac **cmd+s**.",
+      "line": 59
+    },
+    {
+      "file": "main.tf",
+      "description": "Executa o plan:\n\n- **terraform plan**",
+      "line": 60
+    },
+    {
+      "file": "main.tf",
+      "description": "⚠️ Repara que os recursos criados no **Exercício 1** vão ser recriados. Isto acontece porque apesar de terem sido destruídos na atividade anterior continuam declarados no código.",
+      "line": 61
+    },
+    {
+      "file": "main.tf",
+      "description": "Executa o apply:\n\n- **terraform apply**\n\n❗Não te esqueças de escrever yes para confirmar o apply.\n\n⌛Tempo do apply 2:00 min.",
+      "line": 62
+    },
+    {
+      "file": "main.tf",
+      "description": "Verifica que a tua virtual machine foi criada!\n\n- **az vm show -g=$(terraform output -raw my_identifier)-rg -n=$(terraform output -raw my_identifier)-vm -d --output table**\n\nSe quiseres ver todas as virtual machines criadas executa o comando:\n\n- **az vm list --output table**",
+      "line": 63
+    },
+    {
+      "file": "main.tf",
+      "description": "2.1 **Introduzindo alterações não-disruptivas**\n\n- Localiza o recurso **azurerm_virtual_machine.default** e descomenta o campo **tags** (seleciona o conteúdo e prime **ctrl+k+u** ou se estiveres num mac **cmd+k+u**).",
+      "line": 51,
+      "selection": {
+        "start": {
+          "line": 3,
+          "character": 81
+        },
+        "end": {
+          "line": 3,
+          "character": 85
+        }
+      }
+    },
+    {
+      "file": "main.tf",
+      "description": "Não te esqueças de salvar o ficheiro depois de fazeres alterações!\n\n- **ctrl+s** ou se estiveres num mac **cmd+s**.",
+      "line": 80
+    },
+    {
+      "file": "main.tf",
+      "description": "Executa o plan:\n\n- **terraform plan**",
+      "line": 81
+    },
+    {
+      "file": "main.tf",
+      "description": "Executa o apply:\n\n- **terraform apply**\n\n⌛Tempo do apply 30 sec.",
+      "line": 82
+    },
+    {
+      "file": "main.tf",
+      "description": "Podes ver a tag que adicionaste à tua Virtual Machine com o comando:\n\n- **az vm show --name $(terraform output -raw my_identifier)-vm --resource-group $(terraform output -raw my_identifier)-rg --query \"tags\"**",
+      "line": 83
+    },
+    {
+      "file": "main.tf",
+      "description": "2.2 **Introduzindo alterações disruptivas**\n\nLocaliza o recurso **azurerm_virtual_machine.default** e altera o campo *name* para o seguinte:\n\n- **\"${random_pet.this.id}-vm-new\"**",
+      "line": 52
+    },
+    {
+      "file": "main.tf",
+      "description": "❗Guarda as tuas alterações! **ctrl+s** ou se estiveres num mac **cmd+s**.\n\n- Executa o **terraform plan** e verifica que o Terraform irá efectuar um *replacement* - é uma alteração disruptiva.",
+      "line": 53,
+      "selection": {
+        "start": {
+          "line": 3,
+          "character": 76
+        },
+        "end": {
+          "line": 3,
+          "character": 87
+        }
+      }
+    },
+    {
+      "file": "main.tf",
+      "description": "Executa o apply:\n\n- **terraform apply**\n\n⌛Tempo do apply 2 min.\n",
+      "line": 54
+    },
+    {
+      "file": "main.tf",
+      "description": "Verifica que a nova virtual machine foi criada!\n\n- **az vm show -g=$(terraform output -raw my_identifier)-rg -n=$(terraform output -raw my_identifier)-vm-new -d --output table**",
+      "line": 55
+    },
+    {
+      "file": "main.tf",
+      "description": "Para veres todas as Virtual Machines executa o comando:\n\n- **az vm list --output table**",
+      "line": 56
+    },
+    {
+      "file": "terraform.tfvars",
+      "description": "2.3 **Introduzindo alterações dependentes**\n\n- Altera o valor da variavel prefix de **az** para **new**\n\n❗Guarda as tuas alterações! **ctrl+s** ou se estiveres num mac **cmd+s**.",
+      "line": 3
+    },
+    {
+      "file": "terraform.tfvars",
+      "description": "Executa o plan e verifica que todo o grafo de dependências é afetado:\n\n- **terraform plan**",
+      "line": 4
+    },
+    {
+      "file": "terraform.tfvars",
+      "description": "Executa o apply\n\n- **terraform apply**\n\n⌛Tempo do apply 4:00 min.\n\n*Notem que apenas alterámos uma mera variável...*",
+      "line": 5
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "3. **[Terraform Import](https://developer.hashicorp.com/terraform/tutorials/state/state-import) & Move**\n\nTerraform supports bringing your existing infrastructure under its management. By importing resources into Terraform, you can consistently manage your infrastructure using a common workflow.\n\nThis is a great way to slowly transition infrastructure to Terraform, or to be able to be confident that you can use Terraform in the future if it potentially doesn't support every feature you need today.\n",
+      "line": 1
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Assegura-te que não existem alterações pendententes:\n\n- **terraform plan**",
+      "line": 2
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Se o plan apresentar mudanças, façam o apply com o comando:\n\n- **terraform apply**",
+      "line": 3,
+      "selection": {
+        "start": {
+          "line": 3,
+          "character": 5
+        },
+        "end": {
+          "line": 3,
+          "character": 20
+        }
+      }
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "3.1 **Criar um recurso (azurerm_virtual_network) usando os comandos azure**\n\nNesta parte vamos criar recursos recorrendo a uma ferramenta externa ao terraform por forma a criar um use-case de recursos que existem fora do state do terraform.\n\nO objetivo é simular recursos que já existiam para que os possamos terraformar.",
+      "line": 4
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Cria uma Virtual Network com o comando:\n\n- **az network vnet create --name=$(terraform output -raw my_identifier)-import-vnet --subscription=\"$(terraform output -raw subscription_name)\" --resource-group=$(terraform output -raw my_identifier)-rg**\n\n\n⌛Tempo para a criação do recurso 30 segundos.",
+      "line": 5
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Para verificar se a virtual network foi criada:\n\n- **az network vnet show --name=$(terraform output -raw my_identifier)-import-vnet --subscription=\"$(terraform output -raw subscription_name)\" --resource-group=$(terraform output -raw my_identifier)-rg --output table**",
+      "line": 6
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Para verificar todas as virtual networks existentes:\n\n- **az network vnet list --output table**",
+      "line": 7
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "3.2 **Importar recursos existentes**\n\nNesta parte vamos criar o bloco de import para fazer a importação do recurso criado anteriormente.\n\nO processo de importação de recursos consiste em duas partes:\n\n- Obtenção da informação do recurso na cloud.\n- Criação de um bloco import que irá indicar ao terraform que o recurso já existe e que o mesmo deve ser gerido pelo terraform.\n\n\nO primeiro passo da importação de recursos é declarar a importação dos mesmos.\n\nPara isto, temos que definir o bloco import, que necessita de dois argumentos:\n\n- id: o id do recurso a importar do lado de Azure\n- to: o identificador terraform do recurso a importar",
+      "line": 8
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Para o exercicio que segue, descomenta o conteúdo no ficheiro **import-exercise.tf** (seleciona o conteúdo e prime **ctrl+k+u** ou se estiveres num mac **cmd+k+u**).\n\n❗Não te esqueças de gravar as tuas alterações com **ctrl+s** ou se estiveres num mac **cmd+s**.\n",
+      "line": 9
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "O que estamos a fazer é a definir um **bloco de import** em que especificamos o recurso a importar e o seu destino.\n\nTemos no entanto de definir o destino do mesmo para que possamos alojar o recurso e passar a geri-lo por terraform, é essa a razão pela qual definimos um **bloco de resource** no import-exercise.tf.\n\n",
+      "line": 10
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Executa o plan:\n\n- **terraform plan**\n\nO resultado do plan deverá de apresentar:\n\n```Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.```",
+      "line": 11
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Executa o apply:\n\n- **terraform apply**\n\n⌛Tempo do apply - 10 segundos.",
+      "line": 12
+    },
+    {
+      "file": "import-exercise.tf",
+      "description": "Executa o plan:\n\n- **terraform plan**\n\nSe o terraform indicar que não tem alterações à infraestrutura, confirma-se que os recursos foram importados com sucesso.",
+      "line": 13
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "3.3 **Move**\n\nO [move](https://developer.hashicorp.com/terraform/cli/state/move) é usado em casos onde é importante preservar o objeto existente na infraestrutura, reorganizando a nossa configuração de Terraform, renomeando recursos, entre outros casos mais complexos como movendo recursos entre módulos.\n\nVamos agora supôr que queremos mudar o nome dum recurso em terraform. Se formos mudar o nome do recurso, o terraform irá considerar que estamos a destruir o recurso anterior e a querer criar um novo com as mesmas especificações.\n\nPara evitar esse comportamento, uma vez que não queremos destruir o recurso, vamos usar o move.",
+      "line": 1
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "No ficheiro **move-exercise.tf** descomenta o **resource** do **random.pet** (seleciona o conteúdo e prime **ctrl+k+u** ou se estiveres num mac **cmd+k+u**).",
+      "line": 2
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Executa o plan:\n\n- **terraform plan**",
+      "line": 3
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Executa o apply:\n\n- **terraform apply**\n\n⌛Tempo do apply - 20 segundos.",
+      "line": 4
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Agora, vamos mudar o nome do recurso **resource \"random_pet\" \"new_id\"**.\n\nAltera o nome para:\n\n- **resource \"random_pet\" \"moved\"**.",
+      "line": 5
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Executa um plan:\n\n- **terraform plan**",
+      "line": 6
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Como podem ver, ao alterar o nome do recurso o terraform pretende destruir o recurso anterior e criar um novo.\n\n⚠️ **NÃO DESTRUIR OS RECURSOS / NÃO FAZER APPLY DOS RECURSOS**",
+      "line": 7
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Para alterar o nome do recurso sem que o mesmo seja destruído, descomentamos o **bloco de moved**.\n\nIsto fará com que o nome do recurso seja alterado, evitando que este seja destruído e recriado.\n\n- seleciona o conteúdo e prime **ctrl+k+u** ou **cmd+k+u** se estiveres num mac",
+      "line": 8
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Executa o plan:\n\n- **terraform plan**",
+      "line": 9
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "O resultado deverá ser algo como:\n\n```random_pet.new_id has moved to random_pet.moved```",
+      "line": 10
+    },
+    {
+      "file": "move-exercise.tf",
+      "description": "Executa o apply:\n\n- **terraform apply**\n\n⌛Tempo do apply - 20 segundos.\n\nDesta forma, conseguimos manter o mesmo objeto e mudar o seu nome, sem ter de o destruir!",
+      "line": 11
+    },
+    {
+      "file": "final-exercise.tf",
+      "description": "4. **Exercício**\n\nNeste exercicio o objectivo é aplicar alguns dos conhecimentos adquiridos nesta sessão sem que exista uma solução pronta para descomentarem 😉.\n\n👉 Criar uma User-Assigned Managed Identity com os seguintes requisitos:\n- name deverá ser prefixada com valor definido no recurso random_pet.this.id para evitar colisões de nomes\n\n👉 Criar uma Azure Virtual Machine com os seguintes requisitos:\n- Nome da máquina deverá ser: ${random_pet.this.id}-vm-final\n- Tipo de máquina: Standard_B1ls\n- Zona: westeurope\n- Deverá conter uma tag.\n- A rede (subnetwork) onde a VM vai correr fica ao vosso critério: podem criar uma nova, ou podem usar as já existentes.\n- A máquina deverá correr com a azurerm_user_assigned_identity previamente criada.\n\n👉 Devem fazer o exercicio no ficheiro final-exercise.tf.",
+      "line": 1
+    },
+    {
+      "file": "final-exercise.tf",
+      "description": "Ajudas😵\n💡 Usem a pesquisa no terraform registry / azure para saberem mais informação acerca dos recursos que estão a usar:\n\n- [azurerm_user_assigned_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity)\n- [azurerm_virtual_machine](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine)\n- [azurerm_network_interface](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface)\n- [azurerm_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)\n\n💡 Uma subnet já existente poderá ser **azurerm_subnet.default.id.**",
+      "line": 2
+    },
+    {
+      "file": "main.tf",
+      "description": "5. **Wrap-up & Destroy**\n\nDestruir os conteúdos!\n\n- terraform destroy\n\n🔚🏁 Chegámos ao fim 🏁🔚",
+      "line": 113
+    }
+  ],
+  "ref": "main"
+}

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,8 @@ resource "azurerm_subnet" "default" {
 #   admin_password                  = "Password1234!"
 #   disable_password_authentication = false
 #   network_interface_ids           = [azurerm_network_interface.default.id]
+#   patch_assessment_mode           = "AutomaticByPlatform"
+#   provision_vm_agent              = true
 #   os_disk {
 #     caching              = "ReadWrite"
 #     storage_account_type = "Standard_LRS"


### PR DESCRIPTION
# Description 📄 

This pull request includes updates to the Azure Terraform workshop tour and a minor change to the `main.tf` file. The tour provides a step-by-step guide for users to follow along with the workshop exercises, while the `main.tf` file includes a new configuration for virtual machine provisioning.

### Key Changes:

**Tour Updates:**

* Added a new tour file `.tours/terraforming-the-cloud-azure-1.tour` that includes detailed steps for setting up and managing Azure resources using Terraform. This tour covers logging into Azure, setting subscriptions, initializing Terraform, applying plans, and importing existing resources.

**Terraform Configuration:**

* Updated `main.tf` to include `patch_assessment_mode` and `provision_vm_agent` settings in the `azurerm_subnet` resource configuration. These settings help automate patch assessments and ensure the VM agent is provisioned.