### PR TITLE
Configuring codetour steps

### DIFF
--- a/.tours/terraforming-the-cloud-azure-1.tour
+++ b/.tours/terraforming-the-cloud-azure-1.tour
@@ -14,16 +14,16 @@
     },
     {
       "file": "README.md",
-      "description": "Para definir a subscrição corre o seguinte comando:\n\n- **az account set --subscription \"insert-value\"**\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n- **az account list --output table**",
+      "description": "Para definir a subscrição corre o seguinte comando:\n\n- **az account set --subscription < insert-value >**\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n- **az account list --output table**",
       "line": 13,
       "selection": {
         "start": {
-          "line": 7,
-          "character": 5
+          "line": 3,
+          "character": 35
         },
         "end": {
-          "line": 7,
-          "character": 35
+          "line": 3,
+          "character": 51
         }
       }
     },
@@ -33,19 +33,9 @@
       "line": 12
     },
     {
-      "file": "README.md",
+      "file": "scripts/get-azure-credentials.sh",
       "description": "Executa o seguinte script com o comando:\n\n- **source ./scripts/get-azure-credentials.sh**",
-      "line": 1,
-      "selection": {
-        "start": {
-          "line": 3,
-          "character": 5
-        },
-        "end": {
-          "line": 3,
-          "character": 46
-        }
-      }
+      "line": 1
     },
     {
       "file": "main.tf",

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Abre a diretoria do projecto:
 cd para o terraforming-the-cloud-azure-basic-part1
 ```
 
-Inicia o codetour:
+Abre a diretoria com o comando:
 
 ```bash
 ctrl+k+ctrl+o


### PR DESCRIPTION
This pull request includes updates to the `.tours/terraforming-the-cloud-azure-1.tour` and `README.md` files to improve clarity and accuracy of instructions.

Instructions improvements:

* [`.tours/terraforming-the-cloud-azure-1.tour`](diffhunk://#diff-f2c609ec83e828294be9853105ccd0df7e9b28fcc01b7062498ec6348df07d9bL17-R26): Updated the description for setting the subscription command to use angle brackets for the placeholder value.
* [`.tours/terraforming-the-cloud-azure-1.tour`](diffhunk://#diff-f2c609ec83e828294be9853105ccd0df7e9b28fcc01b7062498ec6348df07d9bL36-R38): Changed the file reference from `README.md` to `scripts/get-azure-credentials.sh` for the script execution command.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L117-R117): Modified the instructions to open the project directory with a more explicit command description.