### PR TITLE
Updating terraform version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 
 
 terraform {
-  required_version = "1.10.4"
+  required_version = "1.10.5"
   backend "local" {
     path = "terraform.tfstate"
   }


### PR DESCRIPTION
This pull request includes a minor version update to the Terraform configuration file `main.tf`. The required version of Terraform has been updated from `1.10.4` to `1.10.5`.

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL6-R6): Updated the required Terraform version from `1.10.4` to `1.10.5`