### PR TITLE
Tweaking codetour step to include tenant

### DIFF
--- a/.tours/terraforming-the-cloud-azure-1.tour
+++ b/.tours/terraforming-the-cloud-azure-1.tour
@@ -14,7 +14,7 @@
     },
     {
       "file": "README.md",
-      "description": "No terminal faz login em Azure utilizando o comando:\n>> az login --use-device-code",
+      "description": "No terminal faz login em Azure utilizando o comando:\n>> az login --use-device-code --tenant nosportugal.onmicrosoft.com",
       "line": 11
     },
     {


### PR DESCRIPTION
This pull request includes a small change to the `.tours/terraforming-the-cloud-azure-1.tour` file. The change updates the Azure login command to include a specific tenant identifier.

* [`.tours/terraforming-the-cloud-azure-1.tour`](diffhunk://#diff-f2c609ec83e828294be9853105ccd0df7e9b28fcc01b7062498ec6348df07d9bL17-R17): Updated the Azure login command to use `--tenant nosportugal.onmicrosoft.com` for specifying the tenant.