### PR TITLE
Tweaking codetour steps to make them more concise and intuitive

### DIFF
--- a/.tours/terraforming-the-cloud-azure-1.tour
+++ b/.tours/terraforming-the-cloud-azure-1.tour
@@ -19,7 +19,7 @@
     },
     {
       "file": "README.md",
-      "description": "Para definir a subscrição:\n\n- Seleciona-a de entre as opções disponíveis no teu terminal recorrendo ao Nº da mesma.\n\nAlternativamente executa o comando:\n\n- **az account set --subscription < insert-value >** (Subscription ID ou Subscription Name)\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n>> az account list --output table",
+      "description": "Para definir a subscrição:\n\n- Seleciona-a de entre as opções disponíveis no teu terminal recorrendo ao Nº da mesma.\n\nAlternativamente executa o comando:\n\n>> az account set --subscription tto-terraform-workshops-np\n\nSe quiseres ver todas as tuas subscrições utiliza:\n\n>> az account list --output table",
       "line": 13,
       "selection": {
         "start": {
@@ -59,21 +59,6 @@
     },
     {
       "file": "main.tf",
-      "description": "**[terraform plan](https://developer.hashicorp.com/terraform/cli/commands/plan)**\n\nO comando terraform plan cria um plano de execução, permitindo visualizar antecipadamente as alterações que o Terraform pretende fazer à infraestrutura. Por predefinição, quando o Terraform cria um plan:\n\n- Lê o estado atual de quaisquer objetos remotos existentes para garantir que o estado do Terraform está atualizado.\n- Compara a configuração atual com o estado anterior e regista quaisquer diferenças.\n- Propõe um conjunto de ações que, se aplicadas, farão com que os objetos remotos correspondam à configuração.",
-      "line": 1
-    },
-    {
-      "file": "main.tf",
-      "description": "**[terraform apply](https://developer.hashicorp.com/terraform/cli/commands/apply)**\n\n- O comando terraform apply executa as ações propostas num plan de Terraform.",
-      "line": 2
-    },
-    {
-      "file": "main.tf",
-      "description": "**[terraform destroy](https://developer.hashicorp.com/terraform/cli/commands/destroy)**\n\n- O comando terraform destroy é uma forma prática de destruir todos os objetos geridos por uma determinada configuração de Terraform.\n\nEmbora normalmente não se queira destruir objetos num ambiente de produção, o Terraform é, por vezes, utilizado para gerir infraestrutura efémera para fins de desenvolvimento. Nesse caso, podemos utilizar o terraform destroy para apagar todos estes recursos.",
-      "line": 3
-    },
-    {
-      "file": "main.tf",
       "description": "Para começar executa o comando:\n\n>> terraform init",
       "line": 2,
       "selection": {
@@ -89,8 +74,18 @@
     },
     {
       "file": "main.tf",
+      "description": "**[terraform plan](https://developer.hashicorp.com/terraform/cli/commands/plan)**\n\nO comando terraform plan cria um plano de execução, permitindo visualizar antecipadamente as alterações que o Terraform pretende fazer à infraestrutura. Por predefinição, quando o Terraform cria um plan:\n\n- Lê o estado atual de quaisquer objetos remotos existentes para garantir que o estado do Terraform está atualizado.\n- Compara a configuração atual com o estado anterior e regista quaisquer diferenças.\n- Propõe um conjunto de ações que, se aplicadas, farão com que os objetos remotos correspondam à configuração.",
+      "line": 1
+    },
+    {
+      "file": "main.tf",
       "description": "Para veres as alterações a serem feitas à tua infraestrutura executa o comando:\n\n>> terraform plan",
       "line": 3
+    },
+    {
+      "file": "main.tf",
+      "description": "**[terraform apply](https://developer.hashicorp.com/terraform/cli/commands/apply)**\n\n- O comando terraform apply executa as ações propostas num plan de Terraform.",
+      "line": 2
     },
     {
       "file": "main.tf",
@@ -99,7 +94,7 @@
     },
     {
       "file": "main.tf",
-      "description": "Para verificares que os recursos remotos foram criados executa o comando:\n\n>> az group show --name=$(terraform output -raw my_identifier)-rg --output table",
+      "description": "Para verificares que os recursos remotos foram criados executa o comando:\n\n>> az group show --name=$(terraform output -raw my_identifier)-rg --output table\n\nExamina todos os resource groups criados com o comando:\n\n>> az group list --output table",
       "line": 5,
       "selection": {
         "start": {
@@ -114,8 +109,8 @@
     },
     {
       "file": "main.tf",
-      "description": "Examina todos os resource groups criados com o comando:\n\n>> az group list --output table",
-      "line": 6
+      "description": "**[terraform destroy](https://developer.hashicorp.com/terraform/cli/commands/destroy)**\n\n- O comando terraform destroy é uma forma prática de destruir todos os objetos geridos por uma determinada configuração de Terraform.\n\nEmbora normalmente não se queira destruir objetos num ambiente de produção, o Terraform é, por vezes, utilizado para gerir infraestrutura efémera para fins de desenvolvimento. Nesse caso, podemos utilizar o terraform destroy para apagar todos estes recursos.",
+      "line": 3
     },
     {
       "file": "main.tf",
@@ -124,7 +119,7 @@
     },
     {
       "file": "main.tf",
-      "description": "Confirma a destruição dos recursos:\n\n>> az group show --name=$(terraform output -raw my_identifier)-rg\n\n\nDeverá apresentar um erro a dizer **No outputs found** porque estes foram destruídos.",
+      "description": "Confirma a destruição dos recursos:\n\n>> az group list --output table | grep '$(terraform output -raw my_identifier)-rg'\n\nNão deverá apresentar resultados porque estes recursos foram destruídos.",
       "line": 8,
       "selection": {
         "start": {
@@ -139,43 +134,22 @@
     },
     {
       "file": "main.tf",
-      "description": "2. Lidar com as alterações\n\nNesta secção iremos demonstrar a utilização de terraform perante vários tipos de alterações.\n\nDescomenta o bloco referente ao **Exercicio 2.**\n\nSeleciona o bloco referente ao **Exercício 2** e prime:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.",
-      "line": 58,
       "selection": {
         "start": {
-          "line": 9,
+          "line": 72,
           "character": 1
         },
         "end": {
-          "line": 10,
-          "character": 20
+          "line": 125,
+          "character": 4
         }
-      }
+      },
+      "description": "2. Lidar com as alterações\n\nNesta secção iremos demonstrar a utilização de terraform perante vários tipos de alterações.\n\nDescomenta o bloco referente ao **Exercicio 2.**\n\nSeleciona o bloco referente ao **Exercício 2** e prime:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n\n❗Certifica-te que o ficheiro está guardado com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**."
     },
     {
       "file": "main.tf",
-      "description": "❗Certifica-te que o ficheiro está guardado com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**.",
-      "line": 59,
-      "selection": {
-        "start": {
-          "line": 3,
-          "character": 1
-        },
-        "end": {
-          "line": 4,
-          "character": 18
-        }
-      }
-    },
-    {
-      "file": "main.tf",
-      "description": "Executa o plan:\n\n>> terraform plan",
+      "description": "Executa o plan:\n\n>> terraform plan\n\n⚠️ Repara que os recursos criados no **Exercício 1** vão ser recriados. Isto acontece porque apesar de terem sido destruídos na atividade anterior continuam declarados no código.",
       "line": 60
-    },
-    {
-      "file": "main.tf",
-      "description": "⚠️ Repara que os recursos criados no **Exercício 1** vão ser recriados. Isto acontece porque apesar de terem sido destruídos na atividade anterior continuam declarados no código.",
-      "line": 61
     },
     {
       "file": "main.tf",
@@ -189,23 +163,22 @@
     },
     {
       "file": "main.tf",
-      "description": "Localiza o recurso **azurerm_virtual_machine.default** e descomenta o campo **tags**\n\nSeleciona o conteúdo e prime:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n",
-      "line": 64
+      "selection": {
+        "start": {
+          "line": 94,
+          "character": 1
+        },
+        "end": {
+          "line": 97,
+          "character": 8
+        }
+      },
+      "description": "Localiza o recurso **azurerm_virtual_machine.default** e descomenta o campo **tags**\n\nSeleciona o conteúdo e prime:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n\n❗Certifica-te que o ficheiro está guardado com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**."
     },
     {
       "file": "main.tf",
-      "description": "❗Certifica-te que o ficheiro está guardado com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**.",
-      "line": 80
-    },
-    {
-      "file": "main.tf",
-      "description": "Executa o plan:\n\n>> terraform plan",
+      "description": "Executa o plan:\n\n>> terraform plan\n\nExecuta o apply:\n\n>> terraform apply\n\n⌛Tempo do apply 30 sec.",
       "line": 81
-    },
-    {
-      "file": "main.tf",
-      "description": "Executa o apply:\n\n>> terraform apply\n\n⌛Tempo do apply 30 sec.",
-      "line": 82
     },
     {
       "file": "main.tf",
@@ -214,43 +187,27 @@
     },
     {
       "file": "main.tf",
-      "description": "2.2 **Introduzindo alterações disruptivas**\n\nLocaliza o recurso **azurerm_virtual_machine.default** e altera o campo *name* para o seguinte:\n\n- **\"${random_pet.this.id}-vm-new\"**",
-      "line": 65
-    },
-    {
-      "file": "main.tf",
-      "description": "❗Certifica-te que o ficheiro está guardado com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**.",
-      "line": 53,
       "selection": {
         "start": {
-          "line": 3,
-          "character": 76
+          "line": 73,
+          "character": 1
         },
         "end": {
-          "line": 3,
-          "character": 87
+          "line": 73,
+          "character": 65
         }
-      }
+      },
+      "description": "2.2 **Introduzindo alterações disruptivas**\n\nLocaliza o recurso **azurerm_virtual_machine.default** e altera o campo *name* para o seguinte:\n\n- **\"${random_pet.this.id}-vm-new\"**\n\n❗Certifica-te que o ficheiro está guardado com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**."
     },
     {
       "file": "main.tf",
-      "description": "- Executa o **terraform plan** e verifica que o Terraform irá efectuar um *replacement* - é uma alteração disruptiva.\n\n>> terraform plan",
+      "description": "- Executa o **terraform plan** e verifica que o Terraform irá efectuar um *replacement* - é uma alteração disruptiva.\n\n>> terraform plan\n\nExecuta o apply:\n\n>> terraform apply\n\n⌛Tempo do apply 2 min.\n",
       "line": 66
     },
     {
       "file": "main.tf",
-      "description": "Executa o apply:\n\n>> terraform apply\n\n⌛Tempo do apply 2 min.\n",
-      "line": 54
-    },
-    {
-      "file": "main.tf",
-      "description": "Verifica que a nova virtual machine foi criada!\n\n>> az vm show -g=$(terraform output -raw my_identifier)-rg -n=$(terraform output -raw my_identifier)-vm-new -d --output table",
+      "description": "Verifica que a nova virtual machine foi criada!\n\n>> az vm show -g=$(terraform output -raw my_identifier)-rg -n=$(terraform output -raw my_identifier)-vm-new -d --output table\n\nPara veres todas as Virtual Machines executa o comando:\n\n>> az vm list --output table",
       "line": 55
-    },
-    {
-      "file": "main.tf",
-      "description": "Para veres todas as Virtual Machines executa o comando:\n\n>> az vm list --output table",
-      "line": 56
     },
     {
       "file": "terraform.tfvars",
@@ -259,13 +216,8 @@
     },
     {
       "file": "terraform.tfvars",
-      "description": "Executa o plan e verifica que todo o grafo de dependências é afetado:\n\n>> terraform plan",
+      "description": "Executa o plan e verifica que todo o grafo de dependências é afetado:\n\n>> terraform plan\n\nExecuta o apply\n\n>> terraform apply\n\n⌛Tempo do apply 4:00 min.\n\n*Notem que apenas alterámos uma mera variável...*",
       "line": 4
-    },
-    {
-      "file": "terraform.tfvars",
-      "description": "Executa o apply\n\n>> terraform apply\n\n⌛Tempo do apply 4:00 min.\n\n*Notem que apenas alterámos uma mera variável...*",
-      "line": 5
     },
     {
       "file": "import-exercise.tf",
@@ -274,43 +226,13 @@
     },
     {
       "file": "import-exercise.tf",
-      "description": "Assegura-te que não existem alterações pendententes:\n\n>> terraform plan",
+      "description": "Assegura-te que não existem alterações pendententes:\n\n>> terraform plan\n\nSe o plan apresentar mudanças, façam o apply com o comando:\n\n>> terraform apply",
       "line": 2
     },
     {
       "file": "import-exercise.tf",
-      "description": "Se o plan apresentar mudanças, façam o apply com o comando:\n\n>> terraform apply",
-      "line": 3,
-      "selection": {
-        "start": {
-          "line": 3,
-          "character": 5
-        },
-        "end": {
-          "line": 3,
-          "character": 20
-        }
-      }
-    },
-    {
-      "file": "import-exercise.tf",
-      "description": "3.1 **Criar um recurso (azurerm_virtual_network) usando os comandos azure**\n\nNesta parte vamos criar recursos recorrendo a uma ferramenta externa ao terraform por forma a criar um use-case de recursos que existem fora do state do terraform.\n\nO objetivo é simular recursos que já existiam para que os possamos terraformar.",
+      "description": "3.1 **Criar um recurso (azurerm_virtual_network) usando os comandos azure**\n\nNesta parte vamos criar recursos recorrendo a uma ferramenta externa ao terraform por forma a criar um use-case de recursos que existem fora do state do terraform.\n\nO objetivo é simular recursos que já existiam para que os possamos terraformar.\n\nCria uma Virtual Network com o comando:\n\n>> az network vnet create --name=$(terraform output -raw my_identifier)-import-vnet --subscription=\"$(terraform output -raw subscription_name)\" --resource-group=$(terraform output -raw my_identifier)-rg\n\n⌛Tempo para a criação do recurso 30 segundos.\n\nPara verificar se a virtual network foi criada:\n\n>> az network vnet show --name=$(terraform output -raw my_identifier)-import-vnet --subscription=\"$(terraform output -raw subscription_name)\" --resource-group=$(terraform output -raw my_identifier)-rg --output table\n\nPara verificar todas as virtual networks existentes:\n\n>> az network vnet list --output table",
       "line": 4
-    },
-    {
-      "file": "import-exercise.tf",
-      "description": "Cria uma Virtual Network com o comando:\n\n>> az network vnet create --name=$(terraform output -raw my_identifier)-import-vnet --subscription=\"$(terraform output -raw subscription_name)\" --resource-group=$(terraform output -raw my_identifier)-rg\n\n\n⌛Tempo para a criação do recurso 30 segundos.",
-      "line": 5
-    },
-    {
-      "file": "import-exercise.tf",
-      "description": "Para verificar se a virtual network foi criada:\n\n>> az network vnet show --name=$(terraform output -raw my_identifier)-import-vnet --subscription=\"$(terraform output -raw subscription_name)\" --resource-group=$(terraform output -raw my_identifier)-rg --output table",
-      "line": 6
-    },
-    {
-      "file": "import-exercise.tf",
-      "description": "Para verificar todas as virtual networks existentes:\n\n>> az network vnet list --output table",
-      "line": 7
     },
     {
       "file": "import-exercise.tf",
@@ -324,13 +246,17 @@
     },
     {
       "file": "import-exercise.tf",
-      "description": "Para o exercicio que segue, descomenta o conteúdo no ficheiro **import-exercise.tf**\n\nUtiliza o comando:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n",
-      "line": 9
-    },
-    {
-      "file": "import-exercise.tf",
-      "description": "❗Verifica se as tuas alterações estão guardadas com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**.\n",
-      "line": 15
+      "selection": {
+        "start": {
+          "line": 21,
+          "character": 1
+        },
+        "end": {
+          "line": 39,
+          "character": 1
+        }
+      },
+      "description": "Para o exercicio que segue, descomenta o conteúdo no ficheiro **import-exercise.tf**\n\nUtiliza o comando:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n\n❗Verifica se as tuas alterações estão guardadas com o comando:\n\n- Windows: **ctrl+s**.\n- Mac: **cmd+s**.\n"
     },
     {
       "file": "import-exercise.tf",
@@ -339,13 +265,8 @@
     },
     {
       "file": "import-exercise.tf",
-      "description": "Executa o plan:\n\n>> terraform plan\n\nO resultado do plan deverá de apresentar:\n\n```Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.```",
+      "description": "Executa o plan:\n\n>> terraform plan\n\nO resultado do plan deverá de apresentar:\n\n```Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.```\n\nExecuta o apply:\n\n>> terraform apply\n\n⌛Tempo do apply - 10 segundos.",
       "line": 11
-    },
-    {
-      "file": "import-exercise.tf",
-      "description": "Executa o apply:\n\n>> terraform apply\n\n⌛Tempo do apply - 10 segundos.",
-      "line": 12
     },
     {
       "file": "import-exercise.tf",
@@ -359,28 +280,31 @@
     },
     {
       "file": "move-exercise.tf",
-      "description": "No ficheiro **move-exercise.tf** descomenta o **resource** do **random.pet** **( Exercicio 3.3.1)**\nSeleciona o conteúdo e utiliza o comando:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.",
-      "line": 2
+      "selection": {
+        "start": {
+          "line": 19,
+          "character": 1
+        },
+        "end": {
+          "line": 23,
+          "character": 4
+        }
+      },
+      "description": "No ficheiro **move-exercise.tf** descomenta o **resource** do **random.pet** **( Exercicio 3.3.1)**\nSeleciona o conteúdo e utiliza o comando:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n\nExecuta o plan:\n\n>> terraform plan\n\nExecuta o apply:\n\n>> terraform apply\n\n⌛Tempo do apply - 20 segundos."
     },
     {
       "file": "move-exercise.tf",
-      "description": "Executa o plan:\n\n>> terraform plan",
-      "line": 3
-    },
-    {
-      "file": "move-exercise.tf",
-      "description": "Executa o apply:\n\n>> terraform apply\n\n⌛Tempo do apply - 20 segundos.",
-      "line": 4
-    },
-    {
-      "file": "move-exercise.tf",
-      "description": "Agora, vamos mudar o nome do recurso **resource \"random_pet\" \"new_id\"**.\n\nAltera o nome para:\n\n- **resource \"random_pet\" \"moved\"**.",
-      "line": 5
-    },
-    {
-      "file": "move-exercise.tf",
-      "description": "Executa um plan:\n\n>> terraform plan",
-      "line": 6
+      "selection": {
+        "start": {
+          "line": 19,
+          "character": 1
+        },
+        "end": {
+          "line": 19,
+          "character": 35
+        }
+      },
+      "description": "Agora, vamos mudar o nome do recurso **resource \"random_pet\" \"new_id\"**.\n\nAltera o nome para:\n\n- **resource \"random_pet\" \"moved\"**."
     },
     {
       "file": "move-exercise.tf",
@@ -389,18 +313,22 @@
     },
     {
       "file": "move-exercise.tf",
-      "description": "Para alterar o nome do recurso sem que o mesmo seja destruído, descomentamos o **bloco moved** **(Exercicio 3.3.2)**.\n\nIsto fará com que o nome do recurso seja alterado, evitando que este seja destruído e recriado.\n\nUtiliza o comando:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n",
-      "line": 8
+      "selection": {
+        "start": {
+          "line": 27,
+          "character": 1
+        },
+        "end": {
+          "line": 30,
+          "character": 4
+        }
+      },
+      "description": "Para alterar o nome do recurso sem que o mesmo seja destruído, descomentamos o **bloco moved** **(Exercicio 3.3.2)**.\n\nIsto fará com que o nome do recurso seja alterado, evitando que este seja destruído e recriado.\n\nUtiliza o comando:\n\n- Windows: **ctrl+k+u**\n- Mac: **cmd+k+u**.\n"
     },
     {
       "file": "move-exercise.tf",
-      "description": "Executa o plan:\n\n>> terraform plan",
+      "description": "Executa o plan:\n\n>> terraform plan\n\nO resultado deverá ser algo como:\n\n```random_pet.new_id has moved to random_pet.moved```",
       "line": 9
-    },
-    {
-      "file": "move-exercise.tf",
-      "description": "O resultado deverá ser algo como:\n\n```random_pet.new_id has moved to random_pet.moved```",
-      "line": 10
     },
     {
       "file": "move-exercise.tf",

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Inicia o tour no canto inferior esquerdo do teu Visual Studio Code:
 
 </details>
 
-## Tutorial
+<!--## Tutorial-->
 
-🧭 [Clica aqui para começar!](tutorial.md)
+<!--🧭 [Clica aqui para começar!](tutorial.md)-->
 
 ### Comandos Úteis
 


### PR DESCRIPTION
This pull request includes various updates and improvements to the `.tours/terraforming-the-cloud-azure-1.tour` file. The changes focus on refining the descriptions, reordering content, and adding new instructions to enhance the clarity and flow of the tutorial.

### Updates to descriptions and instructions:

* Updated the subscription setting command to use a specific subscription name (`tto-terraform-workshops-np`) instead of a placeholder (`< insert-value >`).
* Reordered and reintroduced sections on `terraform plan`, `terraform apply`, and `terraform destroy` commands to improve the logical flow of the tutorial. 
* Enhanced instructions for verifying resource creation and destruction using `az group show` and `az group list` commands.
* Consolidated instructions for handling changes, including uncommenting blocks and saving files, to streamline the tutorial steps. 

### Improvements to exercise sections:

* Added detailed steps for creating and verifying a virtual network using Azure CLI commands in the import exercise section.
* Updated the move exercise section to include detailed steps for renaming resources and ensuring they are not destroyed during the process.

### Minor changes:

* Commented out the tutorial section in the `README.md` file to possibly deprecate or hide it.